### PR TITLE
Set up component testing 

### DIFF
--- a/client/src/components/Comment/__snapshots__/index.test.js.snap
+++ b/client/src/components/Comment/__snapshots__/index.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Comment component renders Matches snapshot DOM node structure 1`] = `
+<DocumentFragment>
+  <section
+    class="text-gray-600 body-font overflow-hidden"
+  >
+    <div
+      class="container px-5 py-24 mx-auto"
+    >
+      <div
+        class="-my-8 divide-y-2 divide-gray-100"
+      >
+        <div
+          class="py-8 flex flex-wrap md:flex-nowrap"
+        >
+          <div
+            class="md:w-64 md:mb-0 mb-6 flex-shrink-0 flex flex-col"
+          >
+            <span
+              class="font-semibold title-font text-gray-700"
+            >
+              //! get users name
+            </span>
+            <span
+              class="mt-1 text-gray-500 text-sm"
+            >
+              //! get comment dateTime
+            </span>
+          </div>
+          <div
+            class="md:flex-grow"
+          >
+            <p
+              class="leading-relaxed"
+            >
+              //! get commentText Glossier echo park pug, church-key sartorial biodiesel vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon party messenger bag selfies, poke vaporware kombucha lumbersexual pork belly polaroid hoodie portland craft beer.
+            </p>
+            <a
+              class="text-indigo-500 inline-flex items-center mt-4"
+            >
+              //! get likeCount Like
+              <svg
+                class="w-4 h-4 ml-2"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M5 12h14"
+                />
+                <path
+                  d="M12 5l7 7-7 7"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;

--- a/client/src/components/Comment/index.test.js
+++ b/client/src/components/Comment/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import CommentList from './index';
+
+afterEach(cleanup);
+
+describe('Comment component renders', () => {
+
+   it('renders', () => {
+      render(<CommentList />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<CommentList />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/CommentForm/__snapshots__/index.test.js.snap
+++ b/client/src/components/CommentForm/__snapshots__/index.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CommentForm component renders Matches snapshot DOM node structure 1`] = `
+<DocumentFragment>
+  <div>
+    <p>
+      Character Count: 0/280
+    </p>
+    <textarea
+      class=""
+    />
+    <button
+      class=""
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/client/src/components/CommentForm/index.js
+++ b/client/src/components/CommentForm/index.js
@@ -1,35 +1,35 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client";
-import { ADD_COMMENT } from "../../utils/mutations";
-import { QUERY_COMMENTS, QUERY_ME } from "../../utils/queries";
+// import { ADD_COMMENT } from "../../utils/mutations";
+// import { QUERY_COMMENTS, QUERY_ME } from "../../utils/queries";
 
 export default function CommentForm() {
 
   const [commentText, setCommentText] = useState("");
   const [characterCount, setCharacterCount] = useState(0);
 
-  const [addComment, { error }] = useMutation(ADD_COMMENT, {
-    update(cache, { data: { addComment } }) {
-      try {
-        // update comment array's cache
-        // could potentially not exist yet, so wrap in a try/catch
-        const { comments } = cache.readQuery({ query: QUERY_COMMENTS });
-        cache.writeQuery({
-          query: QUERY_COMMENTS,
-          data: { comments: [addComment, ...comments] },
-        });
-      } catch (e) {
-        console.error(e);
-      }
+  // const [addComment, { error }] = useMutation(ADD_COMMENT, {
+  //   update(cache, { data: { addComment } }) {
+  //     try {
+  //       // update comment array's cache
+  //       // could potentially not exist yet, so wrap in a try/catch
+  //       const { comments } = cache.readQuery({ query: QUERY_COMMENTS });
+  //       cache.writeQuery({
+  //         query: QUERY_COMMENTS,
+  //         data: { comments: [addComment, ...comments] },
+  //       });
+  //     } catch (e) {
+  //       console.error(e);
+  //     }
 
-      // update me object's cache
-      const { me } = cache.readQuery({ query: QUERY_ME });
-      cache.writeQuery({
-        query: QUERY_ME,
-        data: { me: { ...me, comments: [...me.comments, addComment] } },
-      });
-    },
-  });
+  //     // update me object's cache
+  //     const { me } = cache.readQuery({ query: QUERY_ME });
+  //     cache.writeQuery({
+  //       query: QUERY_ME,
+  //       data: { me: { ...me, comments: [...me.comments, addComment] } },
+  //     });
+  //   },
+  // });
 
   // update state based on form input changes
   const handleChange = (event) => {
@@ -40,40 +40,40 @@ export default function CommentForm() {
   };
 
   // submit form
-  const handleFormSubmit = async (event) => {
-    event.preventDefault();
+  // const handleFormSubmit = async (event) => {
+  //   event.preventDefault();
 
-    try {
-      await addComment({
-        variables: { commentText },
-      });
+  //   try {
+  //     await addComment({
+  //       variables: { commentText },
+  //     });
 
-      // clear form value
-      setCommentText("");
-      setCharacterCount(0);
-    } catch (e) {
-      console.error(e);
-    }
-  };
+  //     // clear form value
+  //     setCommentText("");
+  //     setCharacterCount(0);
+  //   } catch (e) {
+  //     console.error(e);
+  //   }
+  // };
 
   return (
     <div>
       <p
-        className={`m-0 ${characterCount === 280 || error ? "text-error" : ""}`}
+      // className={`m-0 ${characterCount === 280 || error ? "text-error" : ""}`}
       >
         Character Count: {characterCount}/280
-        {error && <span className="ml-2">Something went wrong...</span>}
+        {/* {error && <span className="ml-2">Something went wrong...</span>} */}
       </p>
-      <form className="" onSubmit={handleFormSubmit}>
-        <textarea
-          value={commentText}
-          className=""
-          onChange={handleChange}
-        ></textarea>
-        <button className="" type="submit">
-          Submit
-        </button>
-      </form>
+      {/* <form className="" onSubmit={handleFormSubmit}> */}
+      <textarea
+        value={commentText}
+        className=""
+        onChange={handleChange}
+      ></textarea>
+      <button className="" type="submit">
+        Submit
+      </button>
+      {/* </form> */}
     </div>
   );
 }

--- a/client/src/components/CommentForm/index.test.js
+++ b/client/src/components/CommentForm/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import CommentForm from './index';
+
+afterEach(cleanup);
+
+describe('CommentForm component renders', () => {
+
+   it('renders', () => {
+      render(<CommentForm />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<CommentForm />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/EventCard/__snapshots__/index.test.js.snap
+++ b/client/src/components/EventCard/__snapshots__/index.test.js.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventCard component renders Matches snapshot DOM node structure 1`] = `
+<DocumentFragment>
+  <div
+    class="eventCard"
+  >
+    <div
+      class="rounded-lg mt-2 shadow-lg bg-white	 w-full flex flex-row flex-wrap p-3 antialiased"
+    >
+      <div
+        class="md:w-1/3 w-full"
+      >
+        <img
+          class="rounded-lg shadow-lg antialiased"
+          src="https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png"
+        />
+      </div>
+      <div
+        class="md:w-2/3 w-full px-3 flex flex-row flex-wrap"
+      >
+        <div
+          class="w-full text-gray-700 font-semibold relative pt-3 md:pt-0"
+        >
+          <div
+            class="flex flex-row text-2xl text-amber-500 leading-tight pb-1"
+          >
+             //! get event name Event Name
+          </div>
+          <div
+            class="text-sm text-amber-500 md:absolute pt-3 md:pt-0 top-0 right-0"
+          >
+            //! get kindly points Kindly Points: 
+            <b>
+              +10
+            </b>
+          </div>
+          <div
+            class="text-normal hover:text-cyan-700 cursor-pointer text-cyan-900 pb-4"
+          >
+            <span
+              class="pb-1"
+            >
+              User Host
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1"
+          >
+            <span
+              class=""
+            >
+              //! get event description
+              <b>
+                Description:
+              </b>
+               lorem fdjasfkldsjafkldsjafl fdjsalfkjdsalf dasfjdklsafjdklsaf 
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1"
+          >
+            <span
+              class=""
+            >
+              //! get event location
+              <b>
+                Location:
+              </b>
+              Tolland, CT
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1"
+          >
+            <span
+              class=""
+            >
+              //! get event dateTime
+              <b>
+                Date:
+              </b>
+               04/22/2122
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1"
+          >
+            <span
+              class=""
+            >
+              <b>
+                Time:
+              </b>
+               1pm-3pm
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1 hover:text-orange-300"
+          >
+            <a
+              href=""
+            >
+              <span
+                class=""
+              >
+                <i>
+                  More Information
+                </i>
+              </span>
+            </a>
+          </div>
+          <div
+            class="text-sm text-amber-500 md:absolute pt-3 md:pt-0 bottom-0 right-0"
+          >
+            <button
+              class="bg-cyan-700  hover:bg-orange-300 text-white font-bold py-2 px-4 rounded mt-1"
+            >
+              Be Kind
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/client/src/components/EventCard/index.test.js
+++ b/client/src/components/EventCard/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import EventCard from './index';
+
+afterEach(cleanup);
+
+describe('EventCard component renders', () => {
+
+   it('renders', () => {
+      render(<EventCard />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<EventCard />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/Footer/__snapshots__/index.test.js.snap
+++ b/client/src/components/Footer/__snapshots__/index.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Footer component renders Matches snapshot DOM node structure 1`] = `
+<DocumentFragment>
+  <footer
+    class="w-100 mt-auto bg-secondary p-4"
+  >
+    <div
+      class="container"
+    >
+      ©2021 Kindly
+    </div>
+  </footer>
+</DocumentFragment>
+`;

--- a/client/src/components/Footer/index.test.js
+++ b/client/src/components/Footer/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Footer from './index';
+
+afterEach(cleanup);
+
+describe('Footer component renders', () => {
+
+   it('renders', () => {
+      render(<Footer />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<Footer />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/FriendsList/index.test.js
+++ b/client/src/components/FriendsList/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import FriendList from './index';
+
+afterEach(cleanup);
+
+describe('FriendList component renders', () => {
+
+   it('renders', () => {
+      render(<FriendList />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<FriendList />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/GoodDeed/__snapshots__/index.test.js.snap
+++ b/client/src/components/GoodDeed/__snapshots__/index.test.js.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GoodDeed component renders Matches snapshot DOM node structure 1`] = `
+<DocumentFragment>
+  <div
+    class="goodDeed"
+  >
+    <div
+      class="rounded-lg mt-2 shadow-lg bg-white	 w-full flex flex-row flex-wrap p-3 antialiased"
+    >
+      <div
+        class="md:w-2/3 w-full px-3 flex flex-row flex-wrap"
+      >
+        <div
+          class="w-full text-gray-700 font-semibold relative pt-3 md:pt-0"
+        >
+          <div
+            class="flex flex-row text-2xl text-amber-500 leading-tight pb-1"
+          >
+             //! get good deed title Good Deed Name
+          </div>
+          <div
+            class="text-sm text-amber-500 md:absolute pt-3 md:pt-0 top-0 right-0"
+          >
+            //!we need to be able to add this to the users total on verification Kindly Points: 
+            <b>
+              +5
+            </b>
+          </div>
+          <div
+            class="text-normal hover:text-cyan-700 cursor-pointer text-cyan-900 pb-4"
+          >
+            //! get good deed host
+            <span
+              class="pb-1"
+            >
+              User Host
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1"
+          >
+            <span
+              class=""
+            >
+              //! get good deed description
+              <b>
+                Description:
+              </b>
+               lorem fdjasfkldsjafkldsjafl fdjsalfkjdsalf dasfjdklsafjdklsaf 
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1"
+          >
+            <span
+              class=""
+            >
+              //! get good deed location
+              <b>
+                Location:
+              </b>
+              Tolland, CT
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1"
+          >
+            <span
+              class=""
+            >
+              //! get good deed dateTime
+              <b>
+                Date:
+              </b>
+               04/22/2122
+            </span>
+          </div>
+          <div
+            class="text-normal text-cyan-900 pb-1"
+          >
+            <span
+              class=""
+            >
+              <b>
+                Time:
+              </b>
+               1pm-3pm
+            </span>
+          </div>
+          <div
+            class="text-sm text-amber-500 md:absolute pt-3 md:pt-0 bottom-0 right-0"
+          >
+            <button
+              class="bg-cyan-700  hover:bg-orange-300 text-white font-bold py-2 px-4 rounded mt-1"
+            >
+              Be Kind //! need to add helper after signup
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/client/src/components/GoodDeed/index.test.js
+++ b/client/src/components/GoodDeed/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import GoodDeed from './index';
+
+afterEach(cleanup);
+
+describe('GoodDeed component renders', () => {
+
+   it('renders', () => {
+      render(<GoodDeed />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<GoodDeed />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/Header/index.test.js
+++ b/client/src/components/Header/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Header from './index';
+
+afterEach(cleanup);
+
+describe('Header component renders', () => {
+
+   it('renders', () => {
+      render(<Header />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<Header />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/Reply/index.test.js
+++ b/client/src/components/Reply/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Reply from './index';
+
+afterEach(cleanup);
+
+describe('Reply component renders', () => {
+
+   it('renders', () => {
+      render(<Reply />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<Reply />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/ReplyForm/__snapshots__/index.test.js.snap
+++ b/client/src/components/ReplyForm/__snapshots__/index.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReplyForm component renders Matches snapshot DOM node structure 1`] = `
+<DocumentFragment>
+  <div>
+    <p>
+      Character Count: 0/280
+    </p>
+    <form
+      class=""
+    >
+      <textarea
+        class="form-input col-12 col-md-9"
+        placeholder="reply to this comment..."
+      />
+      <button
+        class="btn col-12 col-md-3"
+        type="submit"
+      >
+        Submit
+      </button>
+    </form>
+  </div>
+</DocumentFragment>
+`;

--- a/client/src/components/ReplyForm/index.js
+++ b/client/src/components/ReplyForm/index.js
@@ -1,48 +1,48 @@
 import { useState } from "react";
 import { useMutation } from "@apollo/client";
-import { ADD_REPLY } from "../../utils/mutations";
+// import { ADD_REPLY } from "../../utils/mutations";
 
 export default function ReplyForm(commentId) {
-const [replyBody, setReplyBody] = useState("");
-const [characterCount, setCharacterCount] = useState(0);
-const [addReply, { error }] = useMutation(ADD_REPLY);
+  const [replyBody, setReplyBody] = useState("");
+  const [characterCount, setCharacterCount] = useState(0);
+  // const [addReply, { error }] = useMutation(ADD_REPLY);
 
-const handleChange = (event) => {
-  if (event.target.value.length <= 280) {
-    setReplyBody(event.target.value);
-    setCharacterCount(event.target.value.length);
-  }
-};
+  const handleChange = (event) => {
+    if (event.target.value.length <= 280) {
+      setReplyBody(event.target.value);
+      setCharacterCount(event.target.value.length);
+    }
+  };
 
-const handleFormSubmit = async (event) => {
-  event.preventDefault();
+  // const handleFormSubmit = async (event) => {
+  //   event.preventDefault();
 
-  try {
-    //! add reply to database
-    await addReply({
-      variables: { replyBody, commentId },
-    });
+  //   try {
+  //     //! add reply to database
+  //     await addReply({
+  //       variables: { replyBody, commentId },
+  //     });
 
-    // clear form value
-    setReplyBody("");
-    setCharacterCount(0);
-  } catch (e) {
-    console.error(e);
-  }
-};
+  //     // clear form value
+  //     setReplyBody("");
+  //     setCharacterCount(0);
+  //   } catch (e) {
+  //     console.error(e);
+  //   }
+  // };
 
 
   return (
     <div>
       <p
-        className={`m-0 ${characterCount === 280 || error ? "text-error" : ""}`}
+      // className={`m-0 ${characterCount === 280 || error ? "text-error" : ""}`}
       >
         Character Count: {characterCount}/280
-        {error && <span className="ml-2">Something went wrong...</span>}
+        {/* {error && <span className="ml-2">Something went wrong...</span>} */}
       </p>
       <form
         className=""
-        onSubmit={handleFormSubmit}
+      // onSubmit={handleFormSubmit}
       >
         <textarea
           placeholder="reply to this comment..."

--- a/client/src/components/ReplyForm/index.test.js
+++ b/client/src/components/ReplyForm/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import ReplyForm from './index';
+
+afterEach(cleanup);
+
+describe('ReplyForm component renders', () => {
+
+   it('renders', () => {
+      render(<ReplyForm />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<ReplyForm />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/Sidebar/index.test.js
+++ b/client/src/components/Sidebar/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Sidebar from './index';
+
+afterEach(cleanup);
+
+describe('Sidebar component renders', () => {
+
+   it('renders', () => {
+      render(<Sidebar />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<Sidebar />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/client/src/components/UpcomingEvents/__snapshots__/index.test.js.snap
+++ b/client/src/components/UpcomingEvents/__snapshots__/index.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpcomingEvents component renders Matches snapshot DOM node structure 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="bg-sky-100 mx-auto text-center rounded w-9/12 mb-2"
+    >
+      <h2
+        class="mb-1 underline"
+      >
+        Upcoming Registered Events
+      </h2>
+      <a
+        class="bg-sky-100"
+        href=""
+      >
+        <div
+          class="text-left px-1"
+        >
+          //! get upcoming event data
+          <h3
+            class="bg-cyan-600 hover:bg-orange-300"
+          >
+            Event Name
+          </h3>
+          <p>
+            Location
+          </p>
+          <p>
+            Date at Start Time- End Time
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/client/src/components/UpcomingEvents/index.test.js
+++ b/client/src/components/UpcomingEvents/index.test.js
@@ -1,0 +1,17 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import UpcomingEvents from './index';
+
+afterEach(cleanup);
+
+describe('UpcomingEvents component renders', () => {
+
+   it('renders', () => {
+      render(<UpcomingEvents />);
+   });
+
+   it('Matches snapshot DOM node structure', () => {
+      const { asFragment } = render(<UpcomingEvents />);
+      expect(asFragment()).toMatchSnapshot();
+   });
+});

--- a/server/__tests__/dateFormat.test.js
+++ b/server/__tests__/dateFormat.test.js
@@ -1,1 +1,0 @@
-// *TODO: Create date format test


### PR DESCRIPTION
Each component has an `index.test.js` script file with skeleton rendering and snapshot tests passing. 

There is also a `reducers.test.js` set up for the reducers specifically -- it's good to separate these out because reducers are essentially middleware functions for component state management. Component tests specifically should only handle what components are rendering and whether constant interactivity (ie, you can submit a form properly) we need is working properly.

I will update the tests when windows of opportunity present themselves.